### PR TITLE
fix for ruby < 2

### DIFF
--- a/spec/lib/scheduled_job_spec.rb
+++ b/spec/lib/scheduled_job_spec.rb
@@ -36,7 +36,7 @@ describe ScheduledJob do
     context 'when the job is in run fast mode' do
       before do
         ScheduledJob.configure do |config|
-          config.fast_mode = -> (_) do
+          config.fast_mode = lambda do |_|
             true
           end
         end


### PR DESCRIPTION
Removing ruby 2 specific syntax. We should not be dependant on ruby 2 in the specs
