### PR TITLE
CA-705 Ensure some delay even when running in fast mode

### DIFF
--- a/lib/scheduled_job.rb
+++ b/lib/scheduled_job.rb
@@ -60,7 +60,7 @@ module ScheduledJob
         callback = ScheduledJob.config.fast_mode
         in_fast_mode = callback ? callback.call(self) : false
 
-        run_at = in_fast_mode ? Time.now.utc : time_to_recur(Time.now.utc)
+        run_at = in_fast_mode ? Time.now.utc + 1 : time_to_recur(Time.now.utc)
 
         Delayed::Job.enqueue(new, :run_at => run_at, :queue => queue_name)
       end

--- a/lib/scheduled_job/version.rb
+++ b/lib/scheduled_job/version.rb
@@ -1,3 +1,3 @@
 module ScheduledJob
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/lib/scheduled_job_spec.rb
+++ b/spec/lib/scheduled_job_spec.rb
@@ -39,12 +39,12 @@ describe ScheduledJob do
           config.fast_mode = lambda { |_| true }
         end
       end
-      it 'uses the current time' do
+      it 'uses the current time plus one second' do
         time = Time.now.utc
         allow(Time).to receive_message_chain(:now, :utc) { time }
 
         expect(Delayed::Job).to receive(:enqueue).with(anything, {
-          :run_at => time,
+          :run_at => time + 1,
           :queue  => UnderTest.queue_name
         })
         UnderTest.schedule_job


### PR DESCRIPTION
When running in fast mode the run at was set to the current time. This
meant that the worker running the job picked up the new job immediatly.
If you have a job that runs quickly this can result in log and job spam.
In order to prevent this and to better honour the back off time in the
delayed job polling time by adding a second to the run at ensures the
job wont get picked up immediatly.
