### PR TITLE
Ensure we cant multiple schedule

### DIFF
--- a/lib/scheduled_job.rb
+++ b/lib/scheduled_job.rb
@@ -78,7 +78,7 @@ module ScheduledJob
     end
 
     def job_exists?(job = nil)
-      conditions = ['handler like ? AND failed_at IS NULL', "%:#{self.name} %"]
+      conditions = ['(handler like ? OR handler like ?) AND failed_at IS NULL', "%:#{self.name} %", "%:#{self.name}\n%"]
       unless job.blank?
         conditions[0] << " AND id != ?"
         conditions << job.id

--- a/lib/scheduled_job/version.rb
+++ b/lib/scheduled_job/version.rb
@@ -1,3 +1,3 @@
 module ScheduledJob
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
When serialized the handler class can end in either a space or a new
line. In this case we werent catching the newline cases and as a result
there was the potential to schedule a job more than once.