### PR TITLE
Adds a sqlite db for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+scheduled_job

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,16 @@
 require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 
+require_relative 'db/connect'
+require 'scheduled_job'
+
 RSpec::Core::RakeTask.new('spec')
+Dir[File.dirname(__FILE__) + '/lib/tasks/**/*.rake'].each { |file| import file }
 
 task :default => :spec
+
+desc "console"
+task :console => :dbconnect do
+  require 'pry'
+  binding.pry # rubocop:disable Lint/Debugger
+end

--- a/db/connect.rb
+++ b/db/connect.rb
@@ -1,0 +1,15 @@
+require 'active_record'
+
+module Db
+  class Connect
+    def self.init
+      ActiveRecord::Base.establish_connection(
+        :adapter => "sqlite3",
+        :dbfile  => ":memory:",
+        :database => "scheduled_job"
+      )
+
+      require_relative 'schema'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,14 @@
+ActiveRecord::Schema.define do
+  create_table :delayed_jobs, :force => true do |table|
+    table.integer  :priority, :default => 0      # Allows some jobs to jump to the front of the queue
+    table.integer  :attempts, :default => 0      # Provides for retries, but still fail eventually.
+    table.text     :handler                      # YAML-encoded string of the object that will do work
+    table.text     :last_error                   # reason for last failure (See Note below)
+    table.datetime :run_at                       # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+    table.datetime :locked_at                    # Set when a client is working on this object
+    table.datetime :failed_at                    # Set when all retries have failed (actually, by default, the record is deleted instead)
+    table.string   :locked_by                    # Who is working on this object (if locked)
+    table.string   :queue                        # The name of the queue this job is in
+    table.timestamps
+  end
+end

--- a/lib/scheduled_job/version.rb
+++ b/lib/scheduled_job/version.rb
@@ -1,3 +1,3 @@
 module ScheduledJob
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,0 +1,4 @@
+desc "initialises a database connection"
+task :dbconnect do
+  Db::Connect.init
+end

--- a/scheduled_job.gemspec
+++ b/scheduled_job.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "sqlite3", "~> 1.3.10"
 end

--- a/spec/lib/scheduled_job_spec.rb
+++ b/spec/lib/scheduled_job_spec.rb
@@ -126,7 +126,7 @@ describe ScheduledJob do
     UnderTest.schedule_job job
   end
 
-  pending 'doesnt find substring jobs as existing' do
+  it 'doesnt find substring jobs as existing' do
     UnderTest.schedule_job
     Test.schedule_job
     expect(Delayed::Job.count).to eq(2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ SimpleCov.start
 require 'bundler/setup'
 Bundler.setup
 
+require_relative '../db/connect'
+Db::Connect.init
+
 require 'scheduled_job' # and any other gems you need
 require 'logger'
 


### PR DESCRIPTION
This adds a db back end so that we can do verifications on the delayed
jobs table. Whilst this actually further couples the project to a db
back end the specs are now really required due to bugs found in recent
releases.