### PR TITLE
Allow job names to be strings or symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,6 @@ Adds local db for development
 # 0.1.0
 Makes available the `rake jobs:reschedule` rake task
 Adds a config to allow the scheduling for more than one instance of the same job
+
+# 0.1.1
+Allows jobs in config to be strings, symbols, or classes. If a string or symbol is provided, it will be resolved to a constant before scheduling the job.

--- a/lib/scheduled_job.rb
+++ b/lib/scheduled_job.rb
@@ -18,6 +18,8 @@ module ScheduledJob
   def self.reschedule
     config.jobs.each do |job, options|
       options[:count].times do
+        job = job.to_s if job.is_a?(Symbol)
+        job = job.constantize if job.is_a?(String)
         job.schedule_job
       end
     end if config.jobs
@@ -34,7 +36,7 @@ module ScheduledJob
 
   def self.validate_job_hash(jobs)
     jobs.each do |klass, options|
-      raise ConfigError.new("Jobs config found invalid class: #{klass}") unless klass.class == Class
+      raise ConfigError.new("Jobs config found invalid class: #{klass}") unless klass.is_a?(Class) || klass.is_a?(Symbol) || klass.is_a?(String)
       raise ConfigError.new("Jobs config found invalid job count: #{options[:count]}") unless options[:count].to_i >= 0
     end
   end

--- a/lib/scheduled_job/version.rb
+++ b/lib/scheduled_job/version.rb
@@ -1,3 +1,3 @@
 module ScheduledJob
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/lib/scheduled_job_spec.rb
+++ b/spec/lib/scheduled_job_spec.rb
@@ -39,35 +39,52 @@ describe ScheduledJob do
   end
 
   describe 'job config' do
-    it 'takes a jobs hash config' do
-      expect {
+    let(:job_class) { UnderTest }
+    let(:job_count) { 1 }
+
+    let(:configure) do
+      lambda do
         ScheduledJob.configure do |config|
-          config.jobs = {
-            UnderTest => { count: 1 }
-          }
+          config.jobs = { job_class => { count: job_count } }
         end
-      }.not_to raise_error
+      end
     end
 
-    context 'validates the job hash' do
-      it 'detects an bad job class' do
-        expect {
-          ScheduledJob.configure do |config|
-            config.jobs = {
-              'UnderTest' => { count: 1 }
-            }
-          end
-        }.to raise_error(ScheduledJob::ConfigError)
+    context 'job class is a class' do
+      it 'considers the jobs hash valid' do
+        expect(configure).not_to raise_error
       end
+    end
 
-      it 'detects a bad job count' do
-        expect {
-          ScheduledJob.configure do |config|
-            config.jobs = {
-              UnderTest => { count: -1 }
-            }
-          end
-        }.to raise_error(ScheduledJob::ConfigError)
+    context 'job class is a string' do
+      let(:job_class) { 'UnderTest' }
+
+      it 'considers the jobs hash valid' do
+        expect(configure).not_to raise_error
+      end
+    end
+
+    context 'job class is a symbol' do
+      let(:job_class) { :UnderTest }
+
+      it 'considers the jobs hash valid' do
+        expect(configure).not_to raise_error
+      end
+    end
+
+    context 'job class is not a class, string, or symbol' do
+      let(:job_class) { 1 }
+
+      it 'raises ConfigError' do
+        expect(configure).to raise_error(ScheduledJob::ConfigError)
+      end
+    end
+
+    context 'job count is not a non-negative integer' do
+      let(:job_count) { -1 }
+
+      it 'raises ConfigError' do
+        expect(configure).to raise_error(ScheduledJob::ConfigError)
       end
     end
   end
@@ -77,7 +94,7 @@ describe ScheduledJob do
       ScheduledJob.configure do |config|
         config.jobs = {
           UnderTest => { count: 1 },
-          Test      => { count: 5 }
+          :Test     => { count: 5 }
         }
       end
     end


### PR DESCRIPTION
This means that the job names can be set before the classes are loaded, and rescheduling will still work as expected.