### PR TITLE
Remove queue name

### DIFF
--- a/lib/scheduled_job.rb
+++ b/lib/scheduled_job.rb
@@ -91,10 +91,6 @@ module ScheduledJob
       end
     end
 
-    def queue_name
-      "Default"
-    end
-
     def random_minutes(base, random_delta)
       random_delta *= -1 if random_delta < 0
       (base + Random.new.rand((-1 * random_delta)..random_delta)).minutes


### PR DESCRIPTION
The default queue name in Delayed::Job is `nil`.

This is a problem because if we assume that workers are using named queues, it should be set in the Delayed::Job config. Otherwise any `.delay` methods on regular objects won't get picked up as their queue won't have a name.