### PR TITLE
Set default_queue_name

### DIFF
--- a/lib/scheduled_job.rb
+++ b/lib/scheduled_job.rb
@@ -115,5 +115,9 @@ module ScheduledJob
     def run_duration_threshold
       self.const_defined?(:RUN_DURATION_THRESHOLD) ? self::RUN_DURATION_THRESHOLD : nil
     end
+
+    def queue_name
+      Delayed::Worker.default_queue_name
+    end
   end
 end


### PR DESCRIPTION
Sets the default queue name to Delayed::Worker.default_queue_name