### PR TITLE
Gracefully handle the case when the delayed_job table doesn't exist b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ Allows jobs in config to be strings, symbols, or classes. If a string or symbol 
 
 # 0.1.2
 Falls back to the Delayed Job default queue name if none is provided. Ensures that the run at is set using UTC timezone. Updates specs to run on the latest ruby version on CI.
+
+# 0.1.3
+Gracefully handle the case when the delayed_job table doesn't exist but `rake jobs:reschedule` is called.
+This is needed is some cases where scheduled_job is deployed in a container and the container needs to start so the table can be created.

--- a/lib/scheduled_job/version.rb
+++ b/lib/scheduled_job/version.rb
@@ -1,3 +1,3 @@
 module ScheduledJob
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/tasks/jobs.rb
+++ b/lib/tasks/jobs.rb
@@ -8,7 +8,11 @@ module ScheduledJob
       namespace:jobs do
         desc "Will schedule all scheduled jobs"
         task :reschedule => :environment do
-          ScheduledJob.reschedule
+          if ActiveRecord::Base.connection.table_exists?('delayed_jobs')
+            ScheduledJob.reschedule
+          else
+            puts "Skipping this rake task as the delayed_jobs table doesn't exist yet."
+          end
         end
       end
     end


### PR DESCRIPTION
…ut `rake jobs:reschedule` is called.

### Testing

Assuming that no DB exists:

Before this PR:
```
$ rake jobs:reschedule
rake aborted!
ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "delayed_jobs" does not exist
LINE 5:                WHERE a.attrelid = '"delayed_jobs"'::regclass
                                          ^
:               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
                FROM pg_attribute a LEFT JOIN pg_attrdef d
                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
               WHERE a.attrelid = '"delayed_jobs"'::regclass
                 AND a.attnum > 0 AND NOT a.attisdropped
               ORDER BY a.attnum
```

With this PR:
```
$ rake jobs:reschedule
Skipping this rake task as the delayed_jobs table doesn't exist yet.
```