### PR TITLE
TL-253 add Coveralls support

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ScheduledJob
 
 [![Build Status](https://travis-ci.org/rightscale/scheduled_job.svg?branch=master)](https://travis-ci.org/rightscale/scheduled_job)
+[![Coverage Status](https://coveralls.io/repos/rightscale/scheduled_job/badge.svg?branch=master&service=github)](https://coveralls.io/github/rightscale/scheduled_job?branch=master)
 
 Scheduled job looks to build on top of the [delayed_job](https://github.com/collectiveidea/delayed_job) project by adding support for jobs that need to recur. Whilst investigating other options we decided that we wanted a very light weight framework that would simply allow us to define worker tasks that need to happen on a regular basis.
 

--- a/scheduled_job.gemspec
+++ b/scheduled_job.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "sqlite3", "~> 1.3.10"
+  spec.add_development_dependency 'coveralls'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'pry'
-require 'simplecov'
-SimpleCov.start
+require 'coveralls'
+Coveralls.wear!
 
 require 'bundler/setup'
 Bundler.setup


### PR DESCRIPTION
@smcgivern, @CallumD : This adds coveralls support to scheduled_job. 

We need to start adding coverage badges at least for the public repos, see https://bookiee.rightscale.com/browse/TL-253