### PR TITLE
CA-10304 badly detecting delayed methods as delayed jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,6 @@ This is needed is some cases where scheduled_job is deployed in a container and 
 
 # 0.2.3
 Updating the acitve* gem dependency versions to support the current release. Also drops travis testing for ruby 1.9.3 which is no longer an officially supported Ruby version.
+
+# 0.2.4
+Updates the way that we detect if an instance of a job has already been scheduled. This was because we were incorrectly seeing a delayed method as an instance of that job already being scheduled.

--- a/lib/scheduled_job/version.rb
+++ b/lib/scheduled_job/version.rb
@@ -1,3 +1,3 @@
 module ScheduledJob
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/spec/lib/scheduled_job_spec.rb
+++ b/spec/lib/scheduled_job_spec.rb
@@ -20,7 +20,10 @@ class Test < UnderTest
 end
 
 describe ScheduledJob do
-  before { ScheduledJob.configure { |config| config.jobs = nil } }
+  before do
+    ScheduledJob.configure { |config| config.jobs = nil }
+    Delayed::Job.delete_all
+  end
 
   let(:under_test) { UnderTest.new }
 
@@ -193,6 +196,12 @@ describe ScheduledJob do
     expect(Delayed::Job).to receive(:where).and_return([])
     expect(Delayed::Job).to receive(:enqueue).with(instance, run_at: "time to recur", queue: "TESTING")
     UnderTest.schedule_job job
+  end
+
+  it 'doesnt find delayed methods as existing' do
+    UnderTest.delay.queue_name
+    UnderTest.schedule_job
+    expect(Delayed::Job.count).to eq(2)
   end
 
   it 'doesnt find substring jobs as existing' do


### PR DESCRIPTION
Spec pretty much tells the story but if we delay a method on a class we
do not want that to be detected as the job being already scheduled. This
  now does a bit more meaningful job name parsing in ruby and matches on
  that. The delayed method handler is no longer getting picked up.